### PR TITLE
Fixed confusion of what "Icon from" refers to

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,7 +190,7 @@ Feel free to check the [issues page][issues-url].
 
 Icon from:
 
-<a target="_blank" href="https://icons8.com/icons/set/credit-card">icon</a> by <a target="_blank" href="https://icons8.com">Icons8</a>
+<a target="_blank" href="https://icons8.com">Icons8</a>
 
 Regexs: Adapted form [here](https://www.w3resource.com/javascript/form/credit-card-validation.php)
 Design Idea: [Dribble](https://dribbble.com/shots/11991452-Daily-UI-Challenge-002-Credit-Card-Checkout-Neumorphism)

--- a/README.md
+++ b/README.md
@@ -188,7 +188,7 @@ Feel free to check the [issues page][issues-url].
 
 🤗 Give a ⭐️ if you like this project!
 
-Icon from:
+Icons from:
 
 <a target="_blank" href="https://icons8.com">Icons8</a>
 


### PR DESCRIPTION
## Explanation

I remove "icon by" because it directs to a part of "Icons8" content

## Screenshot

![Fixed confusion of what Icon from refers to](https://user-images.githubusercontent.com/105750239/169179945-fcf4e2a7-70ca-4e5c-99b1-6accc6ad27c6.PNG)

